### PR TITLE
Don't use tell on IO::Zlib handles 

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -335,8 +335,15 @@ sub _read_tar {
     LOOP:
     while( $handle->read( $chunk, HEAD ) ) {
         ### IO::Zlib doesn't support this yet
-        my $offset = eval { tell $handle } || 'unknown';
-        $@ = '';
+        my $offset;
+        if ( ref($handle) ne 'IO::Zlib' ) {
+            local $@;
+            $offset = eval { tell $handle } || 'unknown';
+            $@ = '';
+        }
+        else {
+            $offset = 'unknown';
+        }
 
         unless( $read++ ) {
             my $gzip = GZIP_MAGIC_NUM;


### PR DESCRIPTION
IO::Zlib doesn't implement tell (or seek, sadly) and it uses AUTOLOAD under the hood to attempt a method call, however, this fails.  If one has defined a $SIG{**DIE**} or $SIG{WARN} handler, it is triggered by Archive::Tar's eval and the tar file fails to read/extract, etc.

So this patch checks the handle and if its blessed into IO::Zlib, it just makes the offset value unknown right off the bat.  I suppose that means when/if IO::Zlib does implement tell this code will have to be reverted, but it doesn't seem like that's a priority looking at the RT queue for IO::Zlib.

I guess another option is to save a handler, undef it, and redefine it after the eval fails but that seems kind of messy to me, compared to this.  Another option would be to just compute and store the offset as byte hunks are read.

So here's my first take on the problem. Any other ideas/solutions?
