### PR TITLE
changed some of the "A"s in the UNPACK constant to "a"

### DIFF
--- a/lib/Archive/Tar/Constant.pm
+++ b/lib/Archive/Tar/Constant.pm
@@ -50,7 +50,7 @@ use constant MODE           => do { 0666 & (0777 & ~umask) };
 use constant STRIP_MODE     => sub { shift() & 0777 };
 use constant CHECK_SUM      => "      ";
 
-use constant UNPACK         => 'A100 A8 A8 A8 a12 A12 A8 A1 A100 A6 A2 A32 A32 A8 A8 A155 x12';	# cdrake - size must be a12 - not A12 - or else screws up huge file sizes (>8gb)
+use constant UNPACK         => 'a100 a8 a8 a8 a12 a12 a8 a1 a100 A6 a2 a32 a32 a8 a8 a155 x12';	# cdrake - size must be a12 - not A12 - or else screws up huge file sizes (>8gb)
 use constant PACK           => 'a100 a8 a8 a8 a12 a12 A8 a1 a100 a6 a2 a32 a32 a8 a8 a155 x12';
 use constant NAME_LENGTH    => 100;
 use constant PREFIX_LENGTH  => 155;


### PR DESCRIPTION
... to allow trailing whitespaces in an archived filename

As of 2.02, Archive::Tar doesn't correctly extract an archive like NEILB/BackPAN-Index-Create-0.12.tar.gz which contains "t/testpan/authors/id/P/PO/POGLE/Wood-Pogle-0.001.tar.gz" and "t/testpan/authors/id/P/PO/POGLE/Wood-Pogle-0.001.tar.gz " (with a trailing whitespace, which is ignored). Changing some of the "A"s in the UNPACK constant should fix this.