### PR TITLE
Fix pod in bin/ptar

### DIFF
--- a/bin/ptar
+++ b/bin/ptar
@@ -93,12 +93,12 @@ sub usage {
 
 =head1 NAME
 
-    ptar - a tar-like program written in perl
+ptar - a tar-like program written in perl
 
 =head1 DESCRIPTION
 
-    ptar is a small, tar look-alike program that uses the perl module
-    Archive::Tar to extract, create and list tar archives.
+ptar is a small, tar look-alike program that uses the perl module
+Archive::Tar to extract, create and list tar archives.
 
 =head1 SYNOPSIS
 
@@ -122,7 +122,7 @@ sub usage {
 
 =head1 SEE ALSO
 
-    tar(1), L<Archive::Tar>.
+L<tar(1)>, L<Archive::Tar>.
 
 =cut
 


### PR DESCRIPTION
Several of the pod paragraphs in this file are indented, making them
verbatim instead of the intended flowing text.

This would cause, for example the L<> link to be displayed not as a link
but as the characters "L" "<" ... ">".  And is is not proper to have a
verbatim paragraph in a NAME section.

This commit merely outdents things so they are no longer considered
verbatim, and creates a link to the tar man page that is referenced.