### PR TITLE
CVE-2016-1238: avoid loading optional modules from default .

### DIFF
--- a/bin/ptar
+++ b/bin/ptar
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 use strict;
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use File::Find;
 use Getopt::Std;
 use Archive::Tar;

--- a/bin/ptardiff
+++ b/bin/ptardiff
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use Archive::Tar;
 use Getopt::Std;

--- a/bin/ptargrep
+++ b/bin/ptargrep
@@ -4,6 +4,7 @@
 # archive.  See 'ptargrep --help' for more documentation.
 #
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use warnings;
 


### PR DESCRIPTION
Avoid loading optional modules from the current directory entry in
@INC that perl adds by default.

If these tools are used in /tmp for example an attacker can use the
. entry as a vector to run code with the rights of the current user.