### PR TITLE
Speed up extract when archive contains lots of files

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -601,6 +601,7 @@ sub extract {
     my $self    = shift;
     my @args    = @_;
     my @files;
+    my $hashmap;
 
     # use the speed optimization for all extracted files
     local($self->{cwd}) = cwd() unless $self->{cwd};
@@ -617,16 +618,15 @@ sub extract {
             ### go find it then
             } else {
 
-                my $found;
-                for my $entry ( @{$self->_data} ) {
-                    next unless $file eq $entry->full_path;
+                # create hash-map once to speed up lookup
+                $hashmap = $hashmap || {
+                    map { $_->full_path, $_ } @{$self->_data}
+                };
 
+                if (exists $hashmap->{$file}) {
                     ### we found the file you're looking for
-                    push @files, $entry;
-                    $found++;
-                }
-
-                unless( $found ) {
+                    push @files, $hashmap->{$file};
+                } else {
                     return $self->_error(
                         qq[Could not find '$file' in archive] );
                 }


### PR DESCRIPTION
Previous lookup code in extract behaved quadratic. Create
hash-map once to speed up the lookup process dramatically.

Unfortunately CPAN passes the full file-list to Archive::Tar,
therefore taking nearly forever to extract big module tarballs.

Fixes https://github.com/sass/perl-libsass/issues/34