### PR TITLE
Fix absolute path handling on VMS.

### DIFF
--- a/lib/Archive/Tar/File.pm
+++ b/lib/Archive/Tar/File.pm
@@ -402,7 +402,15 @@ sub _prefix_and_file {
     $file = pop @dirs if $self->is_dir and not length $file;
 
     ### splitting ../ gives you the relative path in native syntax
-    map { $_ = '..' if $_  eq '-' } @dirs if ON_VMS;
+    ### Remove the root (000000) directory
+    ### The volume from splitpath will also be in native syntax
+    if (ON_VMS) {
+        map { $_ = '..' if $_  eq '-'; $_ = '' if $_ eq '000000' } @dirs;
+        if (length($vol)) {
+            $vol = VMS::Filespec::unixify($vol);
+            unshift @dirs, $vol;
+        }
+    }
 
     my $prefix = File::Spec::Unix->catdir(@dirs);
     return( $prefix, $file );


### PR DESCRIPTION
a00e0305c16256c6f broke absolute path handling on filesystems that
have the concept of a volume because it discarded the volume
returned from splitpath.  This restores that on VMS only.

Also, to get the absolute path test added in 53dac726398c2c08
working on VMS, it's necessary to remove the root directory name
(000000) and ensure all path components are in Unix format.