### PR TITLE
Use four digit year

### DIFF
--- a/lib/Archive/Tar/Constant.pm
+++ b/lib/Archive/Tar/Constant.pm
@@ -59,7 +59,7 @@ use constant PACK           => 'a100 a8 a8 a8 a12 a12 A8 a1 a100 a6 a2 a32 a32 a
 use constant NAME_LENGTH    => 100;
 use constant PREFIX_LENGTH  => 155;
 
-use constant TIME_OFFSET    => ($^O eq "MacOS") ? Time::Local::timelocal(0,0,0,1,0,70) : 0;
+use constant TIME_OFFSET    => ($^O eq "MacOS") ? Time::Local::timelocal(0,0,0,1,0,1970) : 0;
 use constant MAGIC          => "ustar";
 use constant TAR_VERSION    => "00";
 use constant LONGLINK_NAME  => '././@LongLink';


### PR DESCRIPTION
I think the year 1970 has to be 1970, rather than 70. 

   https://github.com/Perl/perl5/blob/blead/pod/perlport.pod#time-and-date

Now that 2070 is closer than 1970, we'll start getting the wrong offset.