### PR TITLE
Archive::Tar: Generalize for EBCDIC

### DIFF
--- a/lib/Archive/Tar/Constant.pm
+++ b/lib/Archive/Tar/Constant.pm
@@ -88,7 +88,10 @@ use constant XZ             => do { !$ENV{'PERL5_AT_NO_XZ'} and
                                 };
 
 use constant GZIP_MAGIC_NUM => qr/^(?:\037\213|\037\235)/;
-use constant BZIP_MAGIC_NUM => qr/^BZh\d/;
+
+                           # ASCII:  B   Z   h    0    9
+use constant BZIP_MAGIC_NUM => qr/^\x42\x5A\x68[\x30-\x39]/;
+
 use constant XZ_MAGIC_NUM   => qr/^\xFD\x37\x7A\x58\x5A\x00/;
 
 use constant CAN_CHOWN      => sub { ($> == 0 and $^O ne "MacOS" and $^O ne "MSWin32") };

--- a/t/02_methods.t
+++ b/t/02_methods.t
@@ -165,11 +165,21 @@ chmod 0644, $COMPRESS_FILE;
     }
 }
 
+my $ebcdic_skip_msg = "File contains an alien character set";
+
 ### read tests ###
-{   my @to_try = ($TAR_FILE);
-    push @to_try, $TGZ_FILE if $Class->has_zlib_support;
-    push @to_try, $TBZ_FILE if $Class->has_bzip2_support;
-    push @to_try, $TXZ_FILE if $Class->has_xz_support;
+SKIP: {
+    my @to_try;
+
+    if (ord 'A' == 65) {
+        push @to_try, $TAR_FILE;
+        push @to_try, $TGZ_FILE if $Class->has_zlib_support;
+        push @to_try, $TBZ_FILE if $Class->has_bzip2_support;
+        push @to_try, $TXZ_FILE if $Class->has_xz_support;
+    }
+    else {
+        skip $ebcdic_skip_msg, 4;
+    }
 
     for my $type( @to_try ) {
 
@@ -352,7 +362,11 @@ chmod 0644, $COMPRESS_FILE;
 }
 
 ### rename/replace_content tests ###
-{   my $tar     = $Class->new;
+
+SKIP: {
+    skip $ebcdic_skip_msg, 9 if ord "A" != 65;
+
+    my $tar     = $Class->new;
     my $from    = 'c';
     my $to      = 'e';
 
@@ -383,7 +397,10 @@ chmod 0644, $COMPRESS_FILE;
 }
 
 ### remove tests ###
-{   my $remove  = 'c';
+SKIP: {
+    skip $ebcdic_skip_msg, 3 if ord "A" != 65;
+
+    my $remove  = 'c';
     my $tar     = $Class->new;
 
     ok( $tar->read( $TAR_FILE ),    "Read in '$TAR_FILE'" );
@@ -399,6 +416,8 @@ chmod 0644, $COMPRESS_FILE;
 
 ### write + read + extract tests ###
 SKIP: {                             ### pesky warnings
+    skip $ebcdic_skip_msg, 326 if ord "A" != 65;
+
     skip('no IO::String', 326) if   !$Archive::Tar::HAS_PERLIO &&
                                     !$Archive::Tar::HAS_PERLIO &&
                                     !$Archive::Tar::HAS_IO_STRING &&
@@ -508,7 +527,10 @@ SKIP: {                             ### pesky warnings
 
 
 ### limited read + extract tests ###
-{   my $tar     = $Class->new;
+SKIP: {                             ### pesky warnings
+    skip $ebcdic_skip_msg, 8 if ord "A" != 65;
+
+    my $tar     = $Class->new;
     my @files   = $tar->read( $TAR_FILE, 0, { limit => 1 } );
     my $obj     = $files[0];
 
@@ -549,7 +571,10 @@ SKIP: {                             ### pesky warnings
 
 
 ### clear tests ###
-{   my $tar     = $Class->new;
+SKIP: {                             ### pesky warnings
+    skip $ebcdic_skip_msg, 3 if ord "A" != 65;
+
+    my $tar     = $Class->new;
     my @files   = $tar->read( $TAR_FILE );
 
     my $cnt = $tar->list_files();

--- a/t/04_resolved_issues.t
+++ b/t/04_resolved_issues.t
@@ -157,7 +157,10 @@ use_ok( $FileClass );
 ### bug #43513: [PATCH] Accept wrong checksums from SunOS and HP-UX tar
 ### like GNU tar does. See here for details:
 ### http://www.gnu.org/software/tar/manual/tar.html#SEC139
-{   ok( 1,                      "Testing bug 43513" );
+SKIP: {
+    skip "File contains an alien character set", 5 if ord "A" != 65;
+
+    ok( 1,                      "Testing bug 43513" );
 
     my $src = File::Spec->catfile( qw[src header signed.tar] );
     my $tar = $Class->new;

--- a/t/05_iter.t
+++ b/t/05_iter.t
@@ -1,8 +1,10 @@
 BEGIN { chdir 't' if -d 't' }
 
-use Test::More 'no_plan';
+use Test::More;
 use strict;
 use lib '../lib';
+
+plan skip_all => "File contains an alien character set" if ord "A" != 65;
 
 my $Class   = 'Archive::Tar';
 my $FClass  = 'Archive::Tar::File';
@@ -63,3 +65,5 @@ for my $index ( \0, 0 .. $#Expect ) {
 	$dotest->("all");
     }
 }
+
+done_testing;

--- a/t/09_roundtrip.t
+++ b/t/09_roundtrip.t
@@ -4,6 +4,8 @@ use Test::More;
 use strict;
 use lib '../lib';
 
+plan skip_all => "Files contain an alien character set" if ord "A" != 65;
+
 use File::Spec ();
 use File::Temp qw( tempfile );
 


### PR DESCRIPTION
The only real change to get Archive::Tar to work on EBCDIC is that the
bzip magic number is based on ASCII characters, and Archive::Tar was
using native values (hence EBCDIC on EBCDIC platforms).  Simply change
this to expect the ASCII values, and everything works.

However, the test files were also changed to skip tests concerning files
shipped with the distribution that were encoded in ASCII.  These would
need, once unarchived, to be translated to EBCDIC for proper comparison.
It's simpler to just skip them.

Files that are archived and unarchived on platforms with the same
character set, or files that contain only binary data work fine.