### PR TITLE
Update links under SEE ALSO

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -1,8 +1,8 @@
 ### the gnu tar specification:
-### http://www.gnu.org/software/tar/manual/tar.html
+### https://www.gnu.org/software/tar/manual/tar.html
 ###
 ### and the pax format spec, which tar derives from:
-### http://www.opengroup.org/onlinepubs/007904975/utilities/pax.html
+### https://www.opengroup.org/onlinepubs/007904975/utilities/pax.html
 
 package Archive::Tar;
 require 5.005_03;
@@ -423,7 +423,7 @@ sub _read_tar {
         }
 
         ### ignore labels:
-        ### http://www.gnu.org/software/tar/manual/html_chapter/Media.html#SEC159
+        ### https://www.gnu.org/software/tar/manual/html_chapter/Media.html#SEC159
         next if $entry->is_label;
 
         if( length $entry->type and ($entry->is_file || $entry->is_longlink) ) {
@@ -2396,22 +2396,11 @@ to an uploaded file, which might be a compressed archive.
 
 =item The GNU tar specification
 
-C<http://www.gnu.org/software/tar/manual/tar.html>
+L<https://www.gnu.org/software/tar/manual/tar.html>
 
 =item The PAX format specification
 
-The specification which tar derives from; C< http://www.opengroup.org/onlinepubs/007904975/utilities/pax.html>
-
-=item A comparison of GNU and POSIX tar standards; C<http://www.delorie.com/gnu/docs/tar/tar_114.html>
-
-=item GNU tar intends to switch to POSIX compatibility
-
-GNU Tar authors have expressed their intention to become completely
-POSIX-compatible; C<http://www.gnu.org/software/tar/manual/html_node/Formats.html>
-
-=item A Comparison between various tar implementations
-
-Lists known issues and incompatibilities; C<http://gd.tuwien.ac.at/utils/archivers/star/README.otherbugs>
+The specification which tar derives from; L<https://pubs.opengroup.org/onlinepubs/007904975/utilities/pax.html>
 
 =back
 


### PR DESCRIPTION
I was reading the perldoc via perldoc.perl.org and noticed that the
links in SEE ALSO were not clickable; so I fixed that.

Then I noticed that some of the links in SEE ALSO were very non-existing
anymore, and I guess at this point the difference between GNU tar and
POSIX is not super interesting anymore because GNU tar has been POSIX
compliant for 10+ years at this point? So I removed those links.

But if you want they could probably also be replaced with pointers to
archive.org or such.