### PR TITLE
symlink tests fail on Windows/msys2

### DIFF
--- a/t/04_resolved_issues.t
+++ b/t/04_resolved_issues.t
@@ -200,6 +200,7 @@ SKIP: {
 ### bug #78030
 ### tests for symlinks with relative paths
 ### seen on MSWin32
+if ($^O ne 'msys') # symlink tests fail on Windows/msys2
 {   ok( 1,                      "Testing bug 78030" );
 		my $archname = 'tmp-symlink.tar.gz';
 		{	#build archive


### PR DESCRIPTION
Making symbolic link '/home/xxx/git/perl5/archive-tar-new/t/tmp/a/b/link.txt' to '../c/ori.txt' failed at t/04_resolved_issues.t line 224.
Could not extract 'tmp/a/b/link.txt' at t/04_resolved_issues.t line 224.
not ok 46 -    In memory extraction/symlinks