### PR TITLE
Support extraction of 'large' (>= ~2 GiB) files

### DIFF
--- a/t/02_methods.t
+++ b/t/02_methods.t
@@ -570,6 +570,34 @@ SKIP: {                             ### pesky warnings
 }
 
 
+### extract tests with different $EXTRACT_BLOCK_SIZE values ###
+SKIP: {                             ### pesky warnings
+    skip $ebcdic_skip_msg, 517 if ord "A" != 65;
+
+    skip('no IO::String', 517) if   !$Archive::Tar::HAS_PERLIO &&
+                                    !$Archive::Tar::HAS_PERLIO &&
+                                    !$Archive::Tar::HAS_IO_STRING &&
+                                    !$Archive::Tar::HAS_IO_STRING;
+
+    my $tar = $Class->new;
+    ok( $tar->read( $TAR_FILE ),    "Read in '$TAR_FILE'" );
+
+    for my $aref (  [$tar,    \@EXPECT_NORMAL],
+                    [$TARBIN, \@EXPECTBIN],
+                    [$TARX,   \@EXPECTX]
+    ) {
+        my($obj, $struct) = @$aref;
+
+        for my $block_size ((1, BLOCK, 1024 * 1024, 2**31 - 4096, 2**31, 2**32)) {
+            local $Archive::Tar::EXTRACT_BLOCK_SIZE = $block_size;
+
+            ok( $obj->extract,  "   Extracted with 'extract'" );
+            check_tar_extract( $obj, $struct );
+        }
+    }
+}
+
+
 ### clear tests ###
 SKIP: {                             ### pesky warnings
     skip $ebcdic_skip_msg, 3 if ord "A" != 65;


### PR DESCRIPTION
When extracting Tar archives with 'large' files (i.e. files larger than ~2 GiB) I noticed that this either didn't work (macOS) or resulted in corrupt/too small files (Linux). While debugging, I noticed that there are limits to the amount of data that `syswrite` writes, on Linux, it's at [(2**31 - 4096) bytes][write-notes] while on macOS, it appears to be at (2**31 - 1) bytes. In addition to that, `syswrite` on Linux doesn't return an error in that case, but just the amount of data actually written (which is well within [the specified behavior of `write(2)`][write]), while on macOS, it returns an error - which explains the behavior I observed. There's also [an older bug report on rt.cpan.org][rt-114602] which seems to describe the same issue on Windows.

This PR changes the code which writes extracted files to (1) write smaller chunks (1 GiB) and (2) write until all data was actually written. This seemed to fix the problem in my tests with the file where the extraction failed before. I'm not sure if this is the best solution for the problem, but at least on Linux, the current implementation seems problematic since it may produce incomplete files without warning or error.

[write]: https://www.man7.org/linux/man-pages/man2/write.2.html
[write-notes]: https://www.man7.org/linux/man-pages/man2/write.2.html#NOTES
[rt-114602]: https://rt.cpan.org/Public/Bug/Display.html?id=114602