### PR TITLE
Pod formatting and test failure fixes

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -2153,25 +2153,31 @@ numbers. Added for compatibility with C<busybox> implementations.
 
 =head2 Tuning the way RESOLVE_SYMLINK will works
 
-	You can tune the behaviour by setting the $Archive::Tar::RESOLVE_SYMLINK variable,
-	or $ENV{PERL5_AT_RESOLVE_SYMLINK} before loading the module Archive::Tar.
+You can tune the behaviour by setting the $Archive::Tar::RESOLVE_SYMLINK variable,
+or $ENV{PERL5_AT_RESOLVE_SYMLINK} before loading the module Archive::Tar.
 
-  Values can be one of the following:
+Values can be one of the following:
 
-		none
-           Disable this mechanism and failed as it was in previous version (<1.88)
+=over 4
 
-		speed (default)
-           If you prefer speed
-           this will read again the whole archive using read() so all entries
-           will be available
+=item none
 
-    memory
-           If you prefer memory
+Disable this mechanism and failed as it was in previous version (<1.88)
 
-	Limitation
+=item speed (default)
 
-		It won't work for terminal, pipe or sockets or every non seekable source.
+If you prefer speed
+this will read again the whole archive using read() so all entries
+will be available
+
+=item memory
+
+If you prefer memory
+
+=back
+
+Limitation: It won't work for terminal, pipe or sockets or every non seekable
+source.
 
 =head2 $Archive::Tar::EXTRACT_BLOCK_SIZE
 

--- a/t/02_methods.t
+++ b/t/02_methods.t
@@ -572,9 +572,9 @@ SKIP: {                             ### pesky warnings
 
 ### extract tests with different $EXTRACT_BLOCK_SIZE values ###
 SKIP: {                             ### pesky warnings
-    skip $ebcdic_skip_msg, 517 if ord "A" != 65;
+    skip $ebcdic_skip_msg, 431 if ord "A" != 65;
 
-    skip('no IO::String', 517) if   !$Archive::Tar::HAS_PERLIO &&
+    skip('no IO::String', 431) if   !$Archive::Tar::HAS_PERLIO &&
                                     !$Archive::Tar::HAS_PERLIO &&
                                     !$Archive::Tar::HAS_IO_STRING &&
                                     !$Archive::Tar::HAS_IO_STRING;
@@ -588,7 +588,7 @@ SKIP: {                             ### pesky warnings
     ) {
         my($obj, $struct) = @$aref;
 
-        for my $block_size ((1, BLOCK, 1024 * 1024, 2**31 - 4096, 2**31, 2**32)) {
+        for my $block_size ((1, BLOCK, 1024 * 1024, 2**31 - 4096, 2**31 - 1)) {
             local $Archive::Tar::EXTRACT_BLOCK_SIZE = $block_size;
 
             ok( $obj->extract,  "   Extracted with 'extract'" );

--- a/t/90_symlink.t
+++ b/t/90_symlink.t
@@ -24,7 +24,7 @@ my %Map     = (
     ],
     File::Spec->catfile( $Dir, "linktest_missing_dir.tar" ) => [
         [ 0, qr/SECURE EXTRACT MODE/ ],
-        [ 0, qr/File exists/ ],
+        [ 0, qr/Could not create directory/ ],
     ],
 );
 


### PR DESCRIPTION
As noted in https://github.com/jib/archive-tar-new/issues/38#issuecomment-1484661446 this should fix the test failures on 32 bit Perls that got introduced in #38.

In addition to the above, this should also fix test failures in `90_symlink.t` (for example [this one](https://www.cpantesters.org/cpan/report/6e8f2482-cb41-11ed-8b1f-13126e8775ea)) that seem to have been caused by localized error messages. I wasn't able to reproduce that though, even though my machines usually actually use a non-English locale. I'm also not sure this is the best way to fix this.

When I looked at the POD I added in #38 on meta::cpan, I noticed that the preceding section (["Tuning the way RESOLVE_SYMLINK will works"](https://metacpan.org/pod/Archive::Tar#Tuning-the-way-RESOLVE_SYMLINK-will-works)) was looking a bit weird, so I also added a commit to improve that. As I didn't fully understand the content of the section, I didn't touch the wording and only tried to improve the formatting.