### PR TITLE
Fix handling filenames with trailing whitespace, update test

### DIFF
--- a/lib/Archive/Tar/File.pm
+++ b/lib/Archive/Tar/File.pm
@@ -259,7 +259,7 @@ sub _new_from_file {
         unless ($type == DIR ) {
             my $fh = IO::File->new;
 
-            unless( $fh->open($path) ) {
+            unless( $fh->open($path, 'r') ) {
                 ### dangling symlinks are fine, stop reading but continue
                 ### creating the object
                 last READ if $type == SYMLINK;

--- a/t/04_resolved_issues.t
+++ b/t/04_resolved_issues.t
@@ -273,8 +273,10 @@ if ($^O ne 'msys') # symlink tests fail on Windows/msys2
   ok( 1,                      "Testing bug 103279" );
 	my $tar = $Class->new;
 	isa_ok( $tar, $Class,       "   Object" );
-	ok( $tar->add_data( 'white_space   ', '' ),
+	ok( open my $fh, '>', 'white_space   ' );
+	ok( $tar->add_files( 'white_space   ', '' ),
 				    "   Add file <white_space   > containing filename with trailing whitespace");
+	unlink 'white_space   ';
 	ok( $tar->extract(),        "	Extract filename with trailing whitespace" );
   SKIP: {
     skip "Windows tries to be clever", 1 if $^O eq 'MSWin32';


### PR DESCRIPTION
This stems from a (bug? feature?) in `IO::File` which allows complex file handle modes and stuff to be indicated in the filename, e.g. `'>file.txt'` or `'| cat file.txt'`. Specifying the file open mode disables this parsing.

This *also* fixes the issue where attempting to add files using `Archive::Tar` (via `add_files()`) with trailing whitespace would fail with `Unable to add file: 'foo ' at ./myscript.pl line 24.`.

Closes #10 (GitHub)
Closes https://rt.cpan.org/Public/Bug/Display.html?id=103279