### PR TITLE
Update test

### DIFF
--- a/t/04_resolved_issues.t
+++ b/t/04_resolved_issues.t
@@ -269,19 +269,25 @@ if ($^O ne 'msys') # symlink tests fail on Windows/msys2
 
 ### bug 103279
 ### retain trailing whitespace on filename
-{
+SKIP: {
   ok( 1,                      "Testing bug 103279" );
 	my $tar = $Class->new;
 	isa_ok( $tar, $Class,       "   Object" );
 	ok( open my $fh, '>', 'white_space   ' );
-	ok( $tar->add_files( 'white_space   ', '' ),
+	ok( close $fh );
+	if (-e 'white_space' && $^O eq 'MSWin32') {
+		# Creating a file under Windows using a name with trailing whitespace
+		# sometimes results in the created filename being stripped of that
+		# whitespace. I.e. open './foo  ' -> creates './foo'.
+		# This is known to only happen with *some* versions of Perl for
+		# Windows, so we must test.
+		skip 'Windows tries to be clever', 1;
+	}
+	ok( $tar->add_files( 'white_space   ' ),
 				    "   Add file <white_space   > containing filename with trailing whitespace");
-	unlink 'white_space   ';
+	ok( unlink 'white_space   ' );
 	ok( $tar->extract(),        "	Extract filename with trailing whitespace" );
-  SKIP: {
-    skip "Windows tries to be clever", 1 if $^O eq 'MSWin32';
-	  ok( ! -e 'white_space',     "	<white_space> should not exist" );
-  }
+	ok( ! -e 'white_space',     "	<white_space> should not exist" );
 	ok( -e 'white_space   ',    "	<white_space   > should exist" );
 	unlink foreach ('white_space   ', 'white_space');
 }


### PR DESCRIPTION
Detect Windows behavior and skip a test that would be derailed by it.

Follow-up to #40. Only took me 2 months 😆

Also, the test was calling `->add_files( 'realfile', '' )` which was resulting in an error message that `''` wasn't a file. So I got rid of the attempt to add `''` (empty sting) to the archive.