### PR TITLE
Allow --format=ustar option for ptar

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ t/06_error.t
 t/07_ptardiff.t
 t/08_ptargrep.t
 t/09_roundtrip.t
+t/10_ptar.t
 t/90_symlink.t
 t/99_pod.t
 t/src/header/signed.tar

--- a/bin/ptar
+++ b/bin/ptar
@@ -8,6 +8,14 @@ use Getopt::Std;
 use Archive::Tar;
 use Data::Dumper;
 
+# Allow (and ignore) --format=ustar, for compatibility with GNU tar
+for (my $i = 0; $i < @ARGV; ++$i) {
+    last if $ARGV[$i] eq '--';
+    splice @ARGV, $i--, 1 if $ARGV[$i] eq '--format=ustar';
+    splice @ARGV, $i--, 2 if $i < $#ARGV
+        && $ARGV[$i] eq '--format' && $ARGV[$i + 1] eq 'ustar';
+}
+
 # Allow historic support for dashless bundled options
 #  tar cvf file.tar
 # is valid (GNU) tar style

--- a/t/10_ptar.t
+++ b/t/10_ptar.t
@@ -13,7 +13,7 @@ my $tarfile = File::Spec->catfile("t", "ptar.tar");
 my $ptar = File::Spec->catfile($Bin, "..", "bin", "ptar");
 my $cmd = "$^X $ptar";
 
-plan tests => 7;
+plan tests => 11;
 my $out;
 
 # Create directory/files
@@ -38,6 +38,16 @@ $out = qx{$cmd -x -f$tarfile};
 is($?, 0, "extract ok");
 is($out, "", "extract silent");
 ok(-e $foo, "extracted foo from archive");
+
+# Create archive with --format=ustar, bundled options
+$out = qx{$cmd --format=ustar -cf $tarfile $foo};
+is($?, 0, "--format=ustar ignored ok");
+is($out, "", "--format=ustar ignored silently");
+
+# Create archive with --format ustar
+$out = qx{$cmd -c -f $tarfile --format ustar $foo};
+is($?, 0, "--format ustar ignored ok");
+is($out, "", "--format ustar ignored silently");
 
 # Cleanup
 END {

--- a/t/10_ptar.t
+++ b/t/10_ptar.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+
+use File::Spec;
+use FindBin '$Bin';
+use Archive::Tar;
+
+# File names
+my $tartest = File::Spec->catfile("t", "ptar");
+my $foo = File::Spec->catfile("t", "ptar", "foo");
+my $tarfile = File::Spec->catfile("t", "ptar.tar");
+my $ptar = File::Spec->catfile($Bin, "..", "bin", "ptar");
+my $cmd = "$^X $ptar";
+
+plan tests => 7;
+my $out;
+
+# Create directory/files
+mkdir $tartest;
+open my $fh, ">", $foo or die $!;
+print $fh "file foo\n";
+close $fh;
+
+# Create archive, dashless options
+$out = qx{$cmd cvf $tarfile $foo};
+is($?, 0, "create ok");
+cmp_ok($out, '=~', qr{foo}, "added foo to archive");
+
+# List contents, -f option first
+$out = qx{$cmd -f $tarfile -t};
+is($?, 0, "list ok");
+cmp_ok($out, '=~', qr{foo}, "foo is in archive");
+
+# Extract contents, no space after -f option
+unlink $foo or die $!;
+$out = qx{$cmd -x -f$tarfile};
+is($?, 0, "extract ok");
+is($out, "", "extract silent");
+ok(-e $foo, "extracted foo from archive");
+
+# Cleanup
+END {
+    unlink $tarfile or die $!;
+    unlink $foo or die $!;
+    rmdir $tartest or die $!;
+}


### PR DESCRIPTION
CPAN distributions should use the standard tar format, “ustar”. However, many modern `tar` utilties create archives in the extended “pax” format instead, which prevents installing affected dists on some systems. Modules like ExtUtils::MakeMaker have been struggling a bit with this problem.

There is a proposal to have ExtUtils::MakeMaker use Archive::Tar’s `ptar` by default, instead of system `tar`:  
https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/349

Meanwhile, some CPAN dists have worked around the problem by adding the `--format=ustar` option to their ExtUtils::MakeMaker `TARFLAGS`. Unfortunately, that option is currently not accepted by `ptar`, so changing EU:MM to use `ptar` by default would break those workarounds.

This PR proposes to allow `ptar` to accept a `--format=ustar` option. If this option is given, `ptar` silently ignores it, because Archive::Tar always uses the “ustar” format anyway.