### PR TITLE
Allow `..` links in secure extract in parent path

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -971,7 +971,7 @@ sub _make_special_file {
                     qq[' has absolute target. Not extracting under SECURE EXTRACT MODE] );
                 return;
             }
-            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
+            if( !defined _symlinks_resolver( $entry->full_path, $linkname, 1 ) ) {
                 $self->_error( qq[Symlink '] . $entry->full_path .
                     qq[' target attempts traversal. Not extracting under SECURE EXTRACT MODE] );
                 return;
@@ -999,7 +999,7 @@ sub _make_special_file {
                     qq[the shared inode.] );
                 return;
             }
-            if( grep { $_ eq '..' } File::Spec->splitdir($linkname) ) {
+            if( !defined _symlinks_resolver( $entry->full_path, $linkname, 1 ) ) {
                 $self->_error( qq[Hardlink '] . $entry->full_path .
                     qq[' target '$linkname' attempts traversal. Not ] .
                     qq[extracting under SECURE EXTRACT MODE: extraction ] .
@@ -2024,7 +2024,7 @@ sub no_string_support {
 }
 
 sub _symlinks_resolver{
-  my ($src, $trg) = @_;
+  my ($src, $trg, $strict) = @_;
   my @src = split /[\/\\]/, $src;
   my @trg = split /[\/\\]/, $trg;
   pop @src; #strip out current object name
@@ -2037,6 +2037,7 @@ sub _symlinks_resolver{
     next if $part eq '.'; #ignore current
     if($part eq '..'){
       #got to parent
+      return if $strict && !@src;
       pop @src;
     }
     else{

--- a/t/90_symlink.t
+++ b/t/90_symlink.t
@@ -53,6 +53,32 @@ my %Map     = (
 
 use_ok( $Class );
 
+{
+    my $tar = $Class->new;
+    $tar->add_data( '.github/README.md', '',
+        { type => 2, linkname => '../README' } );
+
+    local $Archive::Tar::INSECURE_EXTRACT_MODE = 0;
+    ok( $tar->extract_file( '.github/README.md' ),
+        "Extracted symlink target that stays under cwd" );
+
+    unlink File::Spec->catfile( qw[.github README.md] );
+    rmtree( '.github' );
+}
+
+{
+    my $tar = $Class->new;
+    $tar->add_data( 'safe/link', '',
+        { type => 2, linkname => '../../outside' } );
+
+    local $Archive::Tar::INSECURE_EXTRACT_MODE = 0;
+    local $Archive::Tar::WARN = 0;
+    ok( !$tar->extract_file( 'safe/link' ),
+        "Refused symlink target escaping cwd" );
+
+    rmtree( 'safe' );
+}
+
 {   while( my($file, $aref) = each %Map ) {
 
         for my $mode ( 0, 1 ) {


### PR DESCRIPTION
Checks that link targets are in the parent patch using `_symlinks_resolver` with an added strict flag.

This caused issues extracting a `git archive` from perl5, as described on #p5p:

> 15:07 \<tib\> BinGOs It's probably expected but the new Archive::Tar ("refuse symlinks to relative with ..") starting at 3.08 refuses even a git archive from our venerable perl5 repo (git archive HEAD | gzip > source.tar.gz) then perl extract.pl (my $tar = Archive::Tar->new; $tar->read('../source.tar.gz', 1); $tar->extract();) gives Symlink

Assisted-by: OpenAI Codex