### PR TITLE
Fix symlink extraction on Windows when symlink() is available

### DIFF
--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -978,9 +978,16 @@ sub _make_special_file {
             }
         }
         my $fail;
-        if( CAN_SYMLINK ) {
+        if( ON_UNIX ) {
+            ### Unix requires real symlinks here.
             symlink( $entry->linkname, $file ) or $fail++;
 
+        } elsif( CAN_SYMLINK ) {
+            ### Non-Unix symlink support can still fail at runtime.
+            unless( symlink( $entry->linkname, $file ) ) {
+                $self->_extract_special_file_as_plain_file( $entry, $file )
+                    or $fail++;
+            }
         } else {
             $self->_extract_special_file_as_plain_file( $entry, $file )
                 or $fail++;
@@ -1133,7 +1140,9 @@ seach_entry:
 
 		if($Archive::Tar::RESOLVE_SYMLINK!~/none/){
 			if(my $link_entry = shift()){#fallback mode when symlinks are using relative notations ( ../a/./b/text.bin )
-				$file = _symlinks_resolver( $link_entry->name, $file );
+				### use full_path (prefix + name) so relative linknames resolve
+				### correctly; using ->name alone drops the directory prefix
+				$file = _symlinks_resolver( $link_entry->full_path, $file );
 				goto seach_entry if $self->_data;
 
 				#this will be slower than never, but won't failed!

--- a/lib/Archive/Tar.pm
+++ b/lib/Archive/Tar.pm
@@ -978,7 +978,7 @@ sub _make_special_file {
             }
         }
         my $fail;
-        if( ON_UNIX ) {
+        if( CAN_SYMLINK ) {
             symlink( $entry->linkname, $file ) or $fail++;
 
         } else {

--- a/lib/Archive/Tar/Constant.pm
+++ b/lib/Archive/Tar/Constant.pm
@@ -99,10 +99,10 @@ use constant CAN_READLINK   => ($^O ne 'MSWin32' and $^O !~ /RISC(?:[ _])?OS/i a
 use constant ON_UNIX        => ($^O ne 'MSWin32' and $^O ne 'MacOS' and $^O ne 'VMS');
 use constant ON_VMS         => $^O eq 'VMS';
 
-### Check: Does Perl create symlinks?
-### ON_UNIX is false on Windows even when symlink() works (e.g. Win Server 2025
+### Compile-time check: does this perl expose symlink()?
+### ON_UNIX is false on Windows even when symlink() may work (e.g. Win Server 2025
 ### with SeCreateSymbolicLinkPrivilege / Developer Mode enabled, Strawberry Perl
-### 5.38+).  Use $Config{d_symlink} as the authoritative indicator instead.
+### 5.38+). Runtime permissions are checked by the symlink() call itself.
 use Config;
 use constant CAN_SYMLINK    => ($Config::Config{d_symlink} ? 1 : 0);
 

--- a/lib/Archive/Tar/Constant.pm
+++ b/lib/Archive/Tar/Constant.pm
@@ -99,6 +99,13 @@ use constant CAN_READLINK   => ($^O ne 'MSWin32' and $^O !~ /RISC(?:[ _])?OS/i a
 use constant ON_UNIX        => ($^O ne 'MSWin32' and $^O ne 'MacOS' and $^O ne 'VMS');
 use constant ON_VMS         => $^O eq 'VMS';
 
+### Check: Does Perl create symlinks?
+### ON_UNIX is false on Windows even when symlink() works (e.g. Win Server 2025
+### with SeCreateSymbolicLinkPrivilege / Developer Mode enabled, Strawberry Perl
+### 5.38+).  Use $Config{d_symlink} as the authoritative indicator instead.
+use Config;
+use constant CAN_SYMLINK    => ($Config::Config{d_symlink} ? 1 : 0);
+
 sub _list_consts {
     my $class = shift;
     my $pkg   = shift;


### PR DESCRIPTION
`_make_special_file` guards symlink creation with ON_UNIX, a compile-time constant that is always false on Windows regardless of whether symlink() actually works. On Windows Server 2022+ with Developer Mode (or SeCreateSymbolicLinkPrivilege), Strawberry Perl 5.38+ ships with `d_symlink=define` and symlink() succeeds at runtime, but the guard prevents it from ever being called.
Because no symlink is written to disk, the `-l $full_path` check in _extract_file's path traversal loop never fires, so the expected SECURE EXTRACT MODE warning is never generated. Tests 5–8, 15–18 (and 22–23 in 3.12) fail as a result.

A secondary bug exists in the else fallback path (`_extract_special_file_as_plain_file`): it calls _symlinks_resolver($link_entry->name, $linkname); but ->name strips the directory prefix, so the resolver sees ('link', 'orig') instead of ('linktest/link', 'orig') and returns 'orig' rather than 'linktest/orig'. The resolved path then fails the exact full_path lookup.

**Fix**
- Add `CAN_SYMLINK` constant to Constant.pm, derived from `$Config{d_symlink}` rather than $^O. This is true on any Perl build where symlink() works, including Windows.
- Keep ON_UNIX in _make_special_file for Unix (symlink failure remains a hard error). Add elsif CAN_SYMLINK for non-Unix platforms: attempts symlink() and falls back gracefully to _extract_special_file_as_plain_file if it fails at runtime (e.g. Windows without SeCreateSymbolicLinkPrivilege).
- In _find_entry: use $link_entry->full_path (not ->name) when calling _symlinks_resolver, so the directory prefix is preserved and relative linknames resolve to the correct archive path.

**Verified**
All 23 tests in t/90_symlink.t passed on Windows with Strawberry Perl 5.42.2. No regressions on Linux (1709 tests pass).